### PR TITLE
reduce tutorial data size

### DIFF
--- a/doc/tutorial.ipynb
+++ b/doc/tutorial.ipynb
@@ -209,7 +209,7 @@
    "source": [
     "First we open the World Ocean Atlas dataset from the opendap dataset (http://apdrc.soest.hawaii.edu/dods/public_data/WOA/WOA13/1_deg/annual). \n",
     "\n",
-    "Here we read the annual mean Temparature, Salinity and Oxygen on a 1degree grid."
+    "Here we read the annual mean Temparature, Salinity and Oxygen on a 5 degree grid."
    ]
   },
   {
@@ -224,12 +224,15 @@
    "outputs": [],
    "source": [
     "# Read WOA using opendap \n",
-    "Temp_url = 'http://apdrc.soest.hawaii.edu:80/dods/public_data/WOA/WOA13/1_deg/annual/temp'\n",
-    "Salt_url = 'http://apdrc.soest.hawaii.edu:80/dods/public_data/WOA/WOA13/1_deg/annual/salt'\n",
-    "Oxy_url = 'http://apdrc.soest.hawaii.edu:80/dods/public_data/WOA/WOA13/1_deg/annual/doxy'\n",
-    "Temp = xr.open_dataset(Temp_url)\n",
-    "Salt = xr.open_dataset(Salt_url)\n",
-    "Oxygen = xr.open_dataset(Oxy_url)"
+    "Temp_url = 'http://apdrc.soest.hawaii.edu:80/dods/public_data/WOA/WOA13/5_deg/annual/temp'\n",
+    "Salt_url = 'http://apdrc.soest.hawaii.edu:80/dods/public_data/WOA/WOA13/5_deg/annual/salt'\n",
+    "Oxy_url = 'http://apdrc.soest.hawaii.edu:80/dods/public_data/WOA/WOA13/5_deg/annual/doxy'\n",
+    "\n",
+    "ds = xr.merge([\n",
+    "    xr.open_dataset(Temp_url).tmn.load(),\n",
+    "    xr.open_dataset(Salt_url).smn.load(),\n",
+    "    xr.open_dataset(Oxy_url).omn.load()])\n",
+    "ds"
    ]
   },
   {
@@ -267,7 +270,7 @@
    "source": [
     "# histogram of number of data points\n",
     "# histogram of number of data points\n",
-    "hTS = histogram(Salt.san, Temp.tan, bins=[sbins, tbins])\n",
+    "hTS = histogram(ds.smn, ds.tmn, bins=[sbins, tbins])\n",
     "np.log10(hTS.T).plot(levels=31)"
    ]
   },
@@ -297,15 +300,15 @@
     "# Note that depth is a non-uniform axis\n",
     "\n",
     "# Create a dz variable\n",
-    "dz = np.diff(Temp.lev)\n",
+    "dz = np.diff(ds.lev)\n",
     "dz =np.insert(dz, 0, dz[0])\n",
-    "dz = xr.DataArray(dz, coords= {'lev':Temp.lev}, dims='lev')\n",
+    "dz = xr.DataArray(dz, coords= {'lev':ds.lev}, dims='lev')\n",
     "\n",
     "# weight by volume of grid cell (resolution = 5degree, 1degree=110km)\n",
-    "dVol = dz * (5*110e3) * (5*110e3*np.cos(Temp.lat*np.pi/180)) \n",
+    "dVol = dz * (5*110e3) * (5*110e3*np.cos(ds.lat*np.pi/180)) \n",
     "\n",
     "# Note: The weights are automatically broadcast to the right size\n",
-    "hTSw = histogram(Salt.san, Temp.tan, bins=[sbins, tbins], weights=dVol)\n",
+    "hTSw = histogram(ds.smn, ds.tmn, bins=[sbins, tbins], weights=dVol)\n",
     "np.log10(hTSw.T).plot(levels=31, vmin=11.5, vmax=16, cmap='brg')"
    ]
   },
@@ -340,12 +343,12 @@
    },
    "outputs": [],
    "source": [
-    "hTSO2 = (histogram(Salt.san.where(~np.isnan(Oxygen.oan)), \n",
-    "                   Temp.tan.where(~np.isnan(Oxygen.oan)), \n",
+    "hTSO2 = (histogram(ds.smn.where(~np.isnan(ds.omn)), \n",
+    "                   ds.tmn.where(~np.isnan(ds.omn)), \n",
     "                   bins=[sbins, tbins], \n",
-    "                   weights=Oxygen.oan.where(~np.isnan(Oxygen.oan))*dVol)/\n",
-    "                histogram(Salt.san.where(~np.isnan(Oxygen.oan)), \n",
-    "                          Temp.tan.where(~np.isnan(Oxygen.oan)), \n",
+    "                   weights=ds.omn.where(~np.isnan(ds.omn))*dVol)/\n",
+    "                histogram(ds.smn.where(~np.isnan(ds.omn)), \n",
+    "                          ds.tmn.where(~np.isnan(ds.omn)), \n",
     "                          bins=[sbins, tbins], \n",
     "                          weights=dVol))\n",
     "\n",


### PR DESCRIPTION
This switches the tutorial to use the 5-degree data (rather than one degree). RTD builds were crashing, possibly because they were using too much memory. This should help mitigate that.