### PR TITLE
Add density=True option

### DIFF
--- a/xhistogram/core.py
+++ b/xhistogram/core.py
@@ -252,6 +252,8 @@ def histogram(*args, bins=None, axis=None, weights=None, density=False,
                                           block_size=block_size)
 
     if density:
+        # Normalise by dividing by bin counts and areas such that all the
+        # histogram data integrated over all dimensions = 1
         bin_widths = [np.diff(b) for b in bins]
         if n_inputs == 1:
             bin_areas = bin_widths[0]

--- a/xhistogram/core.py
+++ b/xhistogram/core.py
@@ -128,7 +128,17 @@ def _histogram_2d_vectorized(*args, bins=None, weights=None, density=False,
     # just throw out everything outside of the bins, as np.histogram does
     # TODO: make this optional?
     slices = (slice(None),) + (N_inputs * (slice(1, -1),))
-    return bin_counts[slices]
+    bin_counts = bin_counts[slices]
+
+    if density:
+        if N_inputs > 1:
+            raise NotImplementedError("density kwarg only implemented for 1D "
+                                      f"histograms, but there are {N_inputs} "
+                                      "input arrays")
+        db = np.diff(bins[0])
+        bin_counts = bin_counts / db / bin_counts.sum()
+
+    return bin_counts
 
 
 def histogram(*args, bins=None, axis=None, weights=None, density=False,

--- a/xhistogram/core.py
+++ b/xhistogram/core.py
@@ -131,12 +131,18 @@ def _histogram_2d_vectorized(*args, bins=None, weights=None, density=False,
     bin_counts = bin_counts[slices]
 
     if density:
-        if N_inputs > 1:
-            raise NotImplementedError("density kwarg only implemented for 1D "
-                                      f"histograms, but there are {N_inputs} "
-                                      "input arrays")
-        db = np.diff(bins[0])
-        bin_counts = bin_counts / db / bin_counts.sum()
+        bin_widths = [np.diff(b) for b in bins]
+        if N_inputs == 1:
+            bin_areas = bin_widths[0]
+        elif N_inputs == 2:
+            bin_areas = np.outer(*bin_widths)
+        else:
+            # TODO use np.einsum for N-D case?
+            raise NotImplementedError("density=True not implemented for "
+                                      "histograms of dimension > 2, but there "
+                                      f"are {N_inputs} input variables")
+
+        bin_counts = bin_counts / bin_areas / bin_counts.sum()
 
     return bin_counts
 

--- a/xhistogram/core.py
+++ b/xhistogram/core.py
@@ -258,15 +258,12 @@ def histogram(*args, bins=None, axis=None, weights=None, density=False,
         elif n_inputs == 2:
             bin_areas = np.outer(*bin_widths)
         else:
-            # TODO use np.einsum for N-D case?
-            raise NotImplementedError("density=True not implemented for "
-                                      "histograms of dimension > 2, but there "
-                                      f"are {n_inputs} input variables")
+            # Slower, but N-dimensional logic
+            bin_areas = np.prod(np.ix_(*bin_widths))
 
         h = bin_counts / bin_areas / bin_counts.sum()
     else:
         h = bin_counts
-
 
     if h.shape[0] == 1:
         assert do_full_array

--- a/xhistogram/test/test_core.py
+++ b/xhistogram/test/test_core.py
@@ -28,6 +28,33 @@ def test_histogram_results_1d(block_size):
 
 
 @pytest.mark.parametrize('block_size', [None, 1, 2])
+def test_histogram_results_1d_density(block_size):
+    nrows, ncols = 5, 20
+    data = np.random.randn(nrows, ncols)
+    bins = np.linspace(-4, 4, 10)
+
+    h = histogram(data, bins=bins, axis=1, block_size=block_size, density=True)
+    assert h.shape == (nrows, len(bins)-1)
+
+    # make sure we get the same thing as histogram
+    hist, _ = np.histogram(data, bins=bins, density=True)
+    np.testing.assert_allclose(hist, h.sum(axis=0))
+
+    # check integral is 1
+    widths = np.diff(bins)
+    integral = np.sum(hist * widths)
+    np.testing.assert_allclose(integral, 1.0)
+
+    # now try with no axis
+    h_na = histogram(data, bins=bins, block_size=block_size, density=True)
+    np.testing.assert_array_equal(hist, h_na)
+
+    # check integral is 1
+    integral = np.sum(h_na * widths)
+    np.testing.assert_allclose(integral, 1.0)
+
+
+@pytest.mark.parametrize('block_size', [None, 1, 2])
 def test_histogram_results_1d_weighted(block_size):
     nrows, ncols = 5, 20
     data = np.random.randn(nrows, ncols)
@@ -52,7 +79,6 @@ def test_histogram_results_1d_weighted_broadcasting(block_size):
     np.testing.assert_array_equal(2*h, h_w)
 
 
-
 def test_histogram_results_2d():
     nrows, ncols = 5, 20
     data_a = np.random.randn(nrows, ncols)
@@ -68,6 +94,30 @@ def test_histogram_results_2d():
     hist, _, _ = np.histogram2d(data_a.ravel(), data_b.ravel(),
                                 bins=[bins_a, bins_b])
     np.testing.assert_array_equal(hist, h)
+
+
+def test_histogram_results_2d_density():
+    nrows, ncols = 5, 20
+    data_a = np.random.randn(nrows, ncols)
+    data_b = np.random.randn(nrows, ncols)
+    nbins_a = 9
+    bins_a = np.linspace(-4, 4, nbins_a + 1)
+    nbins_b = 10
+    bins_b = np.linspace(-4, 4, nbins_b + 1)
+
+    h = histogram(data_a, data_b, bins=[bins_a, bins_b], density=True)
+    assert h.shape == (nbins_a, nbins_b)
+
+    hist, _, _ = np.histogram2d(data_a.ravel(), data_b.ravel(),
+                                bins=[bins_a, bins_b], density=True)
+    np.testing.assert_allclose(hist, h)
+
+    # check integral is 1
+    widths_a = np.diff(bins_a)
+    widths_b = np.diff(bins_b)
+    areas = np.outer(widths_a, widths_b)
+    integral = np.sum(hist * areas)
+    np.testing.assert_allclose(integral, 1.0)
 
 
 @pytest.mark.parametrize('block_size', [None, 5, 'auto'])

--- a/xhistogram/test/test_core.py
+++ b/xhistogram/test/test_core.py
@@ -120,6 +120,37 @@ def test_histogram_results_2d_density():
     np.testing.assert_allclose(integral, 1.0)
 
 
+def test_histogram_results_3d_density():
+    nrows, ncols = 5, 20
+    data_a = np.random.randn(nrows, ncols)
+    data_b = np.random.randn(nrows, ncols)
+    data_c = np.random.randn(nrows, ncols)
+    nbins_a = 9
+    bins_a = np.linspace(-4, 4, nbins_a + 1)
+    nbins_b = 10
+    bins_b = np.linspace(-4, 4, nbins_b + 1)
+    nbins_c = 9
+    bins_c = np.linspace(-4, 4, nbins_c + 1)
+
+    h = histogram(data_a, data_b, data_c, bins=[bins_a, bins_b, bins_c],
+                  density=True)
+
+    assert h.shape == (nbins_a, nbins_b, nbins_c)
+
+    hist, _ = np.histogramdd((data_a.ravel(), data_b.ravel(), data_c.ravel()),
+                             bins=[bins_a, bins_b, bins_c], density=True)
+
+    np.testing.assert_allclose(hist, h)
+
+    # check integral is 1
+    widths_a = np.diff(bins_a)
+    widths_b = np.diff(bins_b)
+    widths_c = np.diff(bins_c)
+    areas = np.einsum('i,j,k', widths_a, widths_b, widths_c)
+    integral = np.sum(hist * areas)
+    np.testing.assert_allclose(integral, 1.0)
+
+
 @pytest.mark.parametrize('block_size', [None, 5, 'auto'])
 @pytest.mark.parametrize('use_dask', [False, True])
 def test_histogram_shape(use_dask, block_size):

--- a/xhistogram/test/test_xarray.py
+++ b/xhistogram/test/test_xarray.py
@@ -59,6 +59,32 @@ def test_histogram_ones(ones, ndims):
         _check_result(h, d)
 
 
+@pytest.mark.parametrize('ndims', [1, 2, 3, 4])
+def test_histogram_ones_density(ones, ndims):
+    dims = ones.dims
+    if ones.ndim < ndims:
+        pytest.skip(
+            "Don't need to test when number of dimension combinations "
+            "exceeds the number of array dimensions")
+
+    # everything should be in the middle bin (index 1)
+    bins = np.array([0, 0.9, 1.1, 2])
+    bin_area = 0.2
+
+    def _check_result(h_density, d):
+        other_dims = [dim for dim in ones.dims if dim not in d]
+        if len(other_dims) > 0:
+            assert set(other_dims) <= set(h_density.dims)
+
+        # check that all integrals over pdfs at different locations are = 1
+        h_integrals = (h_density * bin_area).sum(dim='ones_bin')
+        np.testing.assert_allclose(h_integrals.values, 1.0)
+
+    for d in combinations(dims, ndims):
+        h_density = histogram(ones, bins=[bins], dim=d, density=True)
+        _check_result(h_density, d)
+
+
 # TODO: refactor this test to use better fixtures
 # (it currently has a ton of loops)
 @pytest.mark.parametrize('ndims', [1, 2, 3, 4])

--- a/xhistogram/xarray.py
+++ b/xhistogram/xarray.py
@@ -159,7 +159,6 @@ def histogram(*args, bins=None, dim=None, weights=None, density=False,
     if density:
         # correct for overcounting the bins which weren't histogrammed along
         n_bins_bystander_dims = da_out.isel(**{bd: 0 for bd in new_dims}).size
-        print(n_bins_bystander_dims)
         da_out = da_out * n_bins_bystander_dims
 
     return da_out

--- a/xhistogram/xarray.py
+++ b/xhistogram/xarray.py
@@ -155,6 +155,13 @@ def histogram(*args, bins=None, dim=None, weights=None, density=False,
 
     da_out = xr.DataArray(h_data, dims=output_dims, coords=all_coords,
                           name=output_name)
+
+    if density:
+        # correct for overcounting the bins which weren't histogrammed along
+        n_bins_bystander_dims = da_out.isel(**{bd: 0 for bd in new_dims}).size
+        print(n_bins_bystander_dims)
+        da_out = da_out * n_bins_bystander_dims
+
     return da_out
 
     # we need weights to be passed through apply_func's alignment algorithm,

--- a/xhistogram/xarray.py
+++ b/xhistogram/xarray.py
@@ -126,7 +126,7 @@ def histogram(*args, bins=None, dim=None, weights=None, density=False,
         axis = None
 
     h_data = _histogram(*args_data, weights=weights_data, bins=bins, axis=axis,
-                        block_size=block_size)
+                        density=density, block_size=block_size)
 
     # create output dims
     new_dims = [a.name + bin_dim_suffix for a in args[:N_args]]


### PR DESCRIPTION
- [x] Closes #4 
- [x] Tests added
- [x] Documented API (already there)

I just did it in the simplest way that @rabernat [described](https://github.com/xgcm/xhistogram/issues/4#issue-469344721).

I left the N-D histogram case for later, and I'm also not sure what would happen if you passed `density=True` for multiple DataArray arguments to `xhistogram.xarray.histogram`.

Someone should double-check the logic because I'm not 100% confident I handled the counting of all the bins correctly.

Also small numerical differences (~10^-17) meant I had to use `np.testing.assert_allclose` instead of `np.testing.assert_arrays_equal`, I assume that's okay?