### PR TITLE
disable doc build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
     env: CONDA_ENV="ci/environment-py38.yml" DOCTEST=false
   - python: 3.8
     env: CONDA_ENV="ci/environment-py38-upstream.yml" DOCTEST=false
-  - python: 3.6
-    env: CONDA_ENV="doc/environment.yml" DOCTEST=true
+#  - python: 3.6
+#    env: CONDA_ENV="doc/environment.yml" DOCTEST=true
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then


### PR DESCRIPTION
I have enabled RTD PR builds (see #32), so we can disable the travis doc build.