### PR TITLE
Add future warning for core API change

### DIFF
--- a/xhistogram/core.py
+++ b/xhistogram/core.py
@@ -13,6 +13,7 @@ from .duck_array_ops import (
     concatenate,
     broadcast_arrays,
 )
+import warnings
 
 
 def _ensure_bins_is_a_list_of_arrays(bins, N_expected):
@@ -207,6 +208,17 @@ def histogram(
     --------
     numpy.histogram, numpy.bincount, numpy.digitize
     """
+
+    # Future warning for https://github.com/xgcm/xhistogram/pull/45
+    warnings.warn(
+        "Future versions of xhistogram.core.histogram will return a "
+        + "tuple containing arrays of the the histogram bins and the "
+        + "histogram values, rather than just an array of the histogram "
+        + "values. This API change will only affect users of "
+        + "xhistogram.core. Users of xhistogram.xarray can ignore this "
+        + "message.",
+        FutureWarning,
+    )
 
     a0 = args[0]
     ndim = a0.ndim

--- a/xhistogram/test/test_core.py
+++ b/xhistogram/test/test_core.py
@@ -7,7 +7,6 @@ from ..core import histogram
 from .fixtures import empty_dask_array
 
 import pytest
-import warnings
 
 
 @pytest.mark.parametrize("density", [False, True])

--- a/xhistogram/test/test_core.py
+++ b/xhistogram/test/test_core.py
@@ -203,16 +203,3 @@ def test_histogram_shape(use_dask, block_size):
         assert c.shape == expected_shape
         if use_dask:
             assert isinstance(c, dsa.Array)
-
-
-# Future warning for https://github.com/xgcm/xhistogram/pull/45
-def test_warnings():
-    with warnings.catch_warnings(record=True) as w:
-        # Cause all warnings to always be triggered.
-        warnings.simplefilter("always")
-        nrows, ncols = 5, 20
-        data = np.random.randn(nrows, ncols)
-        bins = np.linspace(-4, 4, 10)
-        histogram(data, bins=bins)
-        assert len(w) == 1
-        assert issubclass(w[-1].category, FutureWarning)

--- a/xhistogram/test/test_core.py
+++ b/xhistogram/test/test_core.py
@@ -7,6 +7,7 @@ from ..core import histogram
 from .fixtures import empty_dask_array
 
 import pytest
+import warnings
 
 
 @pytest.mark.parametrize("density", [False, True])
@@ -202,3 +203,16 @@ def test_histogram_shape(use_dask, block_size):
         assert c.shape == expected_shape
         if use_dask:
             assert isinstance(c, dsa.Array)
+
+
+# Future warning for https://github.com/xgcm/xhistogram/pull/45
+def test_warnings():
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        nrows, ncols = 5, 20
+        data = np.random.randn(nrows, ncols)
+        bins = np.linspace(-4, 4, 10)
+        histogram(data, bins=bins)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, FutureWarning)

--- a/xhistogram/xarray.py
+++ b/xhistogram/xarray.py
@@ -6,6 +6,7 @@ import xarray as xr
 import numpy as np
 from collections import OrderedDict
 from .core import histogram as _histogram
+import warnings
 
 
 def histogram(
@@ -139,14 +140,21 @@ def histogram(
         dims_to_keep = []
         axis = None
 
-    h_data = _histogram(
-        *args_data,
-        weights=weights_data,
-        bins=bins,
-        axis=axis,
-        density=density,
-        block_size=block_size
-    )
+    # Allow future warning for https://github.com/xgcm/xhistogram/pull/45
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="Future versions of xhistogram\\.core\\.histogram will return",
+            category=FutureWarning,
+        )
+        h_data = _histogram(
+            *args_data,
+            weights=weights_data,
+            bins=bins,
+            axis=axis,
+            density=density,
+            block_size=block_size
+        )
 
     # create output dims
     new_dims = [a.name + bin_dim_suffix for a in args[:N_args]]


### PR DESCRIPTION
https://github.com/xgcm/xhistogram/pull/45 introduces a change to the outputs of xhistogram.core.histogram. This PR adds a FutureWarning to xhistogram.core.histogram to warn users of the upcoming API change.