### PR TITLE
Created checking function for xarray.DataArray and throw an error if not 

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -146,6 +146,9 @@ v0.2.1 (not yet released)
   xhistogram that mimic the numpy histogram API. This included
   adding a range argument to the xhistogram API :issue:`13`.
   By `Dougie Squire <https://github.com/dougiesquire>`_.
+- Added a function to check if the object passed to xhist() is an
+  xarray.DataArray and if not, throw an error. :issue:`14`.
+  By `Yang Yunyi <https://github.com/Badboy-16>`_.
 
 v0.2.0
 ~~~~~~

--- a/xhistogram/test/test_xarray.py
+++ b/xhistogram/test/test_xarray.py
@@ -199,3 +199,10 @@ def test_carry_coords(keep_coords, number_of_inputs):
         assert "lon" in result.coords
     else:
         assert "lon" not in result.coords
+
+
+# test for issue #14
+def test_input_type_check():
+    np_array = np.arange(100)
+    with pytest.raises(TypeError):
+        histogram(np_array)

--- a/xhistogram/xarray.py
+++ b/xhistogram/xarray.py
@@ -106,8 +106,9 @@ def histogram(
     N_weights = 1 if weights is not None else 0
 
     for a in args:
-        # TODO: make this a more robust check
-        assert a.name is not None, "all arrays must have a name"
+        if not isinstance(a, xr.DataArray):
+            raise TypeError(f"xhist() accepts an xr.DataArray object but a " \
+                            f"{type(a).__name__} was given")
 
     # we drop coords to simplify alignment
     if not keep_coords:

--- a/xhistogram/xarray.py
+++ b/xhistogram/xarray.py
@@ -19,7 +19,7 @@ def histogram(
     density=False,
     block_size="auto",
     keep_coords=False,
-    bin_dim_suffix="_bin"
+    bin_dim_suffix="_bin",
 ):
     """Histogram applied along specified dimensions.
 
@@ -107,8 +107,13 @@ def histogram(
 
     for a in args:
         if not isinstance(a, xr.DataArray):
-            raise TypeError(f"xhist() accepts an xr.DataArray object but a " \
-                            f"{type(a).__name__} was given")
+            raise TypeError(
+                "xhistogram.xarray.histogram accepts only xarray.DataArray "
+                + f"objects but a {type(a).__name__} was provided"
+            )
+
+    for a in args:
+        assert a.name is not None, "all arrays must have a name"
 
     # we drop coords to simplify alignment
     if not keep_coords:
@@ -162,7 +167,7 @@ def histogram(
         range=range,
         axis=axis,
         density=density,
-        block_size=block_size
+        block_size=block_size,
     )
 
     # create output dims


### PR DESCRIPTION
I had a go to fix #14 

In the `histogram()` (`xhist()`) function, I added some code to check if the object passed to the function is an instance of xarray.DataArray, and if not, throw a `TypeError`.