### PR TITLE
Test chunking (including Hypothesis tests)

### DIFF
--- a/ci/environment-3.7.yml
+++ b/ci/environment-3.7.yml
@@ -7,6 +7,7 @@ dependencies:
   - dask
   - numpy=1.16
   - pytest
+  - hypothesis
   - pip
   - pip:
     - codecov

--- a/ci/environment-3.8.yml
+++ b/ci/environment-3.8.yml
@@ -7,6 +7,7 @@ dependencies:
   - dask
   - numpy=1.18
   - pytest
+  - hypothesis
   - pip
   - pip:
     - codecov

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -7,6 +7,7 @@ dependencies:
   - dask
   - numpy
   - pytest
+  - hypothesis
   - pip
   - pip:
     - codecov

--- a/xhistogram/core.py
+++ b/xhistogram/core.py
@@ -338,6 +338,7 @@ def histogram(
             new_axes=new_axes,
             adjust_chunks=adjust_chunks,
             meta=np.array((), dtype),
+            align_arrays=False,
             **bincount_kwargs,
         )
         # sum over the block dims

--- a/xhistogram/core.py
+++ b/xhistogram/core.py
@@ -338,7 +338,6 @@ def histogram(
             new_axes=new_axes,
             adjust_chunks=adjust_chunks,
             meta=np.array((), dtype),
-            align_arrays=False,
             **bincount_kwargs,
         )
         # sum over the block dims

--- a/xhistogram/test/fixtures.py
+++ b/xhistogram/test/fixtures.py
@@ -1,5 +1,4 @@
 import uuid
-import pytest
 import dask
 import dask.array as dsa
 import numpy as np
@@ -18,31 +17,23 @@ def empty_dask_array(shape, dtype=float, chunks=None):
     return a
 
 
-@pytest.fixture(scope="module")
-def dataarray_factory():
-    def _dataarray_factory(shape=(5, 20)):
-        data = np.random.randn(*shape)
-        dims = [f"dim_{i}" for i in range(len(shape))]
-        da = xr.DataArray(data, dims=dims, name="T")
-        return da
-
-    return _dataarray_factory
+def example_dataarray(shape=(5, 20)):
+    data = np.random.randn(*shape)
+    dims = [f"dim_{i}" for i in range(len(shape))]
+    da = xr.DataArray(data, dims=dims, name="T")
+    return da
 
 
-@pytest.fixture(scope="module")
-def dataset_factory():
+def example_dataset(n_dim=2, n_vars=2):
     """Random dataset with every variable having the same shape"""
 
-    def _dataset_factory(n_dim=2, n_vars=2):
-        shape = (8, 9, 10, 11)[:n_dim]
-        dims = [f"dim_{i}" for i in range(len(shape))]
-        var_names = [uuid.uuid4().hex for _ in range(n_vars)]
-        ds = xr.Dataset()
-        for i in range(n_vars):
-            name = var_names[i]
-            data = np.random.randn(*shape)
-            da = xr.DataArray(data, dims=dims, name=name)
-            ds[name] = da
-        return ds
-
-    return _dataset_factory
+    shape = (8, 9, 10, 11)[:n_dim]
+    dims = [f"dim_{i}" for i in range(len(shape))]
+    var_names = [uuid.uuid4().hex for _ in range(n_vars)]
+    ds = xr.Dataset()
+    for i in range(n_vars):
+        name = var_names[i]
+        data = np.random.randn(*shape)
+        da = xr.DataArray(data, dims=dims, name=name)
+        ds[name] = da
+    return ds

--- a/xhistogram/test/fixtures.py
+++ b/xhistogram/test/fixtures.py
@@ -1,6 +1,3 @@
-import random
-import string
-
 import pytest
 import dask
 import dask.array as dsa

--- a/xhistogram/test/fixtures.py
+++ b/xhistogram/test/fixtures.py
@@ -32,9 +32,9 @@ def dataarray_factory():
 def dataset_factory():
     """Random dataset with every variable having the same shape"""
 
-    def _dataset_factory(ndim=2, n_vars=2):
-        shape = (8, 9, 10, 11)[:ndim]
-        dims = ["x", "y", "z", "w"][:ndim]
+    def _dataset_factory(n_dim=2, n_vars=2):
+        shape = (8, 9, 10, 11)[:n_dim]
+        dims = ["x", "y", "z", "w"][:n_dim]
         var_names = ["T", "S", "V", "U"]
         ds = xr.Dataset()
         for i in range(n_vars):

--- a/xhistogram/test/fixtures.py
+++ b/xhistogram/test/fixtures.py
@@ -20,11 +20,11 @@ def empty_dask_array(shape, dtype=float, chunks=None):
     return a
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def dataarray_factory():
     def _dataarray_factory(shape=(5,20)):
         data = np.random.randn(*shape)
-        dims = [random.choice(string.ascii_lowercase) for ax in shape]
+        dims = ["x", "y", "z", "w"][:len(shape)]
         da = xr.DataArray(
             data, dims=dims, name="T"
         )
@@ -32,15 +32,16 @@ def dataarray_factory():
     return _dataarray_factory
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def dataset_factory():
     """Random dataset with every variable having the same shape"""
     def _dataset_factory(ndim=2, n_vars=2):
         shape = (8, 9, 10, 11)[:ndim]
-        dims = [random.choice(string.ascii_lowercase) for ax in shape]
+        dims = ["x", "y", "z", "w"][:ndim]
+        var_names = ['T', 'S', 'V', 'U']
         ds = xr.Dataset()
-        for _ in range(n_vars):
-            name = random.choice(string.ascii_uppercase)
+        for i in range(n_vars):
+            name = var_names[i]
             data = np.random.randn(*shape)
             da = xr.DataArray(
                 data, dims=dims, name=name

--- a/xhistogram/test/fixtures.py
+++ b/xhistogram/test/fixtures.py
@@ -1,3 +1,4 @@
+import uuid
 import pytest
 import dask
 import dask.array as dsa
@@ -21,7 +22,7 @@ def empty_dask_array(shape, dtype=float, chunks=None):
 def dataarray_factory():
     def _dataarray_factory(shape=(5, 20)):
         data = np.random.randn(*shape)
-        dims = ["x", "y", "z", "w"][: len(shape)]
+        dims = [f"dim_{i}" for i in range(len(shape))]
         da = xr.DataArray(data, dims=dims, name="T")
         return da
 
@@ -34,8 +35,8 @@ def dataset_factory():
 
     def _dataset_factory(n_dim=2, n_vars=2):
         shape = (8, 9, 10, 11)[:n_dim]
-        dims = ["x", "y", "z", "w"][:n_dim]
-        var_names = ["T", "S", "V", "U"]
+        dims = [f"dim_{i}" for i in range(len(shape))]
+        var_names = [uuid.uuid4().hex for _ in range(n_vars)]
         ds = xr.Dataset()
         for i in range(n_vars):
             name = var_names[i]

--- a/xhistogram/test/fixtures.py
+++ b/xhistogram/test/fixtures.py
@@ -17,32 +17,30 @@ def empty_dask_array(shape, dtype=float, chunks=None):
     return a
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def dataarray_factory():
-    def _dataarray_factory(shape=(5,20)):
+    def _dataarray_factory(shape=(5, 20)):
         data = np.random.randn(*shape)
-        dims = ["x", "y", "z", "w"][:len(shape)]
-        da = xr.DataArray(
-            data, dims=dims, name="T"
-        )
+        dims = ["x", "y", "z", "w"][: len(shape)]
+        da = xr.DataArray(data, dims=dims, name="T")
         return da
+
     return _dataarray_factory
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def dataset_factory():
     """Random dataset with every variable having the same shape"""
+
     def _dataset_factory(ndim=2, n_vars=2):
         shape = (8, 9, 10, 11)[:ndim]
         dims = ["x", "y", "z", "w"][:ndim]
-        var_names = ['T', 'S', 'V', 'U']
+        var_names = ["T", "S", "V", "U"]
         ds = xr.Dataset()
         for i in range(n_vars):
             name = var_names[i]
             data = np.random.randn(*shape)
-            da = xr.DataArray(
-                data, dims=dims, name=name
-            )
+            da = xr.DataArray(data, dims=dims, name=name)
             ds[name] = da
         return ds
 

--- a/xhistogram/test/fixtures.py
+++ b/xhistogram/test/fixtures.py
@@ -1,5 +1,11 @@
+import random
+import string
+
+import pytest
 import dask
 import dask.array as dsa
+import numpy as np
+import xarray as xr
 
 
 def empty_dask_array(shape, dtype=float, chunks=None):
@@ -12,3 +18,34 @@ def empty_dask_array(shape, dtype=float, chunks=None):
         a = a.rechunk(chunks)
 
     return a
+
+
+@pytest.fixture(scope="module")
+def dataarray_factory():
+    def _dataarray_factory(shape=(5,20)):
+        data = np.random.randn(*shape)
+        dims = [random.choice(string.ascii_lowercase) for ax in shape]
+        da = xr.DataArray(
+            data, dims=dims, name="T"
+        )
+        return da
+    return _dataarray_factory
+
+
+@pytest.fixture(scope="module")
+def dataset_factory():
+    """Random dataset with every variable having the same shape"""
+    def _dataset_factory(ndim=2, n_vars=2):
+        shape = (8, 9, 10, 11)[:ndim]
+        dims = [random.choice(string.ascii_lowercase) for ax in shape]
+        ds = xr.Dataset()
+        for _ in range(n_vars):
+            name = random.choice(string.ascii_uppercase)
+            data = np.random.randn(*shape)
+            da = xr.DataArray(
+                data, dims=dims, name=name
+            )
+            ds[name] = da
+        return ds
+
+    return _dataset_factory

--- a/xhistogram/test/fixtures.py
+++ b/xhistogram/test/fixtures.py
@@ -27,7 +27,7 @@ def example_dataarray(shape=(5, 20)):
 def example_dataset(n_dim=2, n_vars=2):
     """Random dataset with every variable having the same shape"""
 
-    shape = (8, 9, 10, 11)[:n_dim]
+    shape = tuple(range(8, 8 + n_dim))
     dims = [f"dim_{i}" for i in range(len(shape))]
     var_names = [uuid.uuid4().hex for _ in range(n_vars)]
     ds = xr.Dataset()

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -14,7 +14,7 @@ def test_chunked_weights(chunksize, shape, weights):
 
     if weights:
         weights = example_dataarray(shape).chunk((chunksize,))
-        weights_arr = weights.values.ravel()
+        weights_arr = weights.values
     else:
         weights = weights_arr = None
 
@@ -25,7 +25,7 @@ def test_chunked_weights(chunksize, shape, weights):
 
     assert h.shape == (nbins_a,)
 
-    hist, _ = np.histogram(data_a.values.ravel(), bins=bins_a, weights=weights_arr)
+    hist, _ = np.histogram(data_a.values, bins=bins_a, weights=weights_arr)
 
     np.testing.assert_allclose(hist, h.values)
 
@@ -44,7 +44,7 @@ class TestFixedSize2DChunks:
 
         assert h.shape == (nbins_a,)
 
-        hist, _ = np.histogram(data_a.values.ravel(), bins=bins_a)
+        hist, _ = np.histogram(data_a.values, bins=bins_a)
 
         np.testing.assert_allclose(hist, h.values)
 
@@ -135,7 +135,7 @@ class TestUnalignedChunks:
         assert h.shape == (nbins_a,)
 
         hist, _ = np.histogram(
-            data_a.values.ravel(), bins=bins_a, weights=weights.values.ravel()
+            data_a.values, bins=bins_a, weights=weights.values
         )
 
         np.testing.assert_allclose(hist, h.values)

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -5,20 +5,28 @@ from .fixtures import example_dataarray
 from ..xarray import histogram
 
 
+@pytest.mark.parametrize("weights", [False, True])
 @pytest.mark.parametrize("chunksize", [1, 2, 3, 10])
 @pytest.mark.parametrize("shape", [(10,), (10, 4)])
-def test_fixed_size_1d_chunks(chunksize, shape):
+def test_chunked_weights(chunksize, shape, weights):
 
     data_a = example_dataarray(shape).chunk((chunksize,))
+    
+    if weights:
+        weights = example_dataarray(shape).chunk((chunksize,))
+        weights_arr = weights.values.ravel()
+    else:
+        weights = weights_arr = None
 
     nbins_a = 6
     bins_a = np.linspace(-4, 4, nbins_a + 1)
 
-    h = histogram(data_a, bins=[bins_a])
+    h = histogram(data_a, bins=[bins_a], weights=weights)
 
     assert h.shape == (nbins_a,)
 
-    hist, _ = np.histogram(data_a.values.ravel(), bins=bins_a)
+    hist, _ = np.histogram(data_a.values.ravel(), bins=bins_a,
+                           weights=weights_arr)
 
     np.testing.assert_allclose(hist, h.values)
 

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -1,16 +1,15 @@
-# flake8: noqa
 import numpy as np
 import pytest
 
-from .fixtures import dataarray_factory, dataset_factory  # noqa
+from .fixtures import example_dataarray
 from ..xarray import histogram
 
 
 @pytest.mark.parametrize("chunksize", [1, 2, 3, 10])
 @pytest.mark.parametrize("shape", [(10,), (10, 4)])
-def test_fixed_size_1d_chunks(dataarray_factory, chunksize, shape):
+def test_fixed_size_1d_chunks(chunksize, shape):
 
-    data_a = dataarray_factory(shape).chunk((chunksize,))
+    data_a = example_dataarray(shape).chunk((chunksize,))
 
     nbins_a = 6
     bins_a = np.linspace(-4, 4, nbins_a + 1)
@@ -27,9 +26,9 @@ def test_fixed_size_1d_chunks(dataarray_factory, chunksize, shape):
 @pytest.mark.parametrize("xchunksize", [1, 2, 3, 10])
 @pytest.mark.parametrize("ychunksize", [1, 2, 3, 12])
 class TestFixedSize2DChunks:
-    def test_2d_chunks(self, dataarray_factory, xchunksize, ychunksize):
+    def test_2d_chunks(self, xchunksize, ychunksize):
 
-        data_a = dataarray_factory(shape=(10, 12)).chunk((xchunksize, ychunksize))
+        data_a = example_dataarray(shape=(10, 12)).chunk((xchunksize, ychunksize))
 
         nbins_a = 8
         bins_a = np.linspace(-4, 4, nbins_a + 1)
@@ -44,11 +43,10 @@ class TestFixedSize2DChunks:
 
     def test_2d_chunks_broadcast_dim(
         self,
-        dataarray_factory,
         xchunksize,
         ychunksize,
     ):
-        data_a = dataarray_factory(shape=(10, 12)).chunk((xchunksize, ychunksize))
+        data_a = example_dataarray(shape=(10, 12)).chunk((xchunksize, ychunksize))
 
         nbins_a = 8
         bins_a = np.linspace(-4, 4, nbins_a + 1)
@@ -66,10 +64,10 @@ class TestFixedSize2DChunks:
 
         np.testing.assert_allclose(hist, h.values)
 
-    def test_2d_chunks_2d_hist(self, dataarray_factory, xchunksize, ychunksize):
+    def test_2d_chunks_2d_hist(self, xchunksize, ychunksize):
 
-        data_a = dataarray_factory(shape=(10, 12)).chunk((xchunksize, ychunksize))
-        data_b = dataarray_factory(shape=(10, 12)).chunk((xchunksize, ychunksize))
+        data_a = example_dataarray(shape=(10, 12)).chunk((xchunksize, ychunksize))
+        data_b = example_dataarray(shape=(10, 12)).chunk((xchunksize, ychunksize))
 
         nbins_a = 8
         nbins_b = 9

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -102,7 +102,6 @@ class TestUnalignedChunks:
         data_b = example_dataarray(shape=(10, 12)).chunk(
             (xchunksize + 1, ychunksize + 1)
         )
-        print(data_b.chunks)
 
         nbins_a = 8
         nbins_b = 9

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -5,8 +5,6 @@ from .fixtures import dataarray_factory, dataset_factory
 from ..xarray import histogram
 
 
-
-
 @pytest.mark.parametrize("chunksize", [1, 2, 3, 10])
 @pytest.mark.parametrize("shape", [(10,), (10,4)])
 def test_fixed_size_1d_chunks(dataarray_factory, chunksize, shape):

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -1,0 +1,178 @@
+import numpy as np
+import pytest
+
+from .fixtures import dataarray_factory, dataset_factory
+from ..xarray import histogram
+
+
+
+
+@pytest.mark.parametrize("chunksize", [1, 2, 3, 10])
+@pytest.mark.parametrize("shape", [(10,), (10,4)])
+def test_fixed_size_1d_chunks(self, dataarray_factory, chunksize, shape):
+
+    data_a = dataarray_factory(shape).chunk((chunksize,))
+
+    nbins_a = 6
+    bins_a = np.linspace(-4, 4, nbins_a + 1)
+
+    h = histogram(data_a, bins=[bins_a])
+
+    assert h.shape == (nbins_a,)
+
+    hist, _ = np.histogram(data_a.values.ravel(), bins=bins_a)
+
+    np.testing.assert_allclose(hist, h.values)
+
+
+@pytest.mark.parametrize("xchunksize", [1, 2, 3, 10])
+@pytest.mark.parametrize("ychunksize", [1, 2, 3, 12])
+class TestFixedSize2DChunks:
+    def test_2d_chunks(self, dataarray_factory, xchunksize, ychunksize):
+
+        data_a = dataarray_factory(shape=(10, 12)).chunk((xchunksize, ychunksize))
+
+        nbins_a = 8
+        bins_a = np.linspace(-4, 4, nbins_a + 1)
+
+        h = histogram(data_a, bins=[bins_a])
+
+        assert h.shape == (nbins_a,)
+
+        hist, _ = np.histogram(data_a.values.ravel(), bins=bins_a)
+
+        np.testing.assert_allclose(hist, h.values)
+
+    def test_2d_chunks_broadcast_dim(self, dataarray_factory, xchunksize, ychunksize):
+        data_a = dataarray_factory(shape=(10, 12)).chunk((xchunksize, ychunksize))
+
+        nbins_a = 8
+        bins_a = np.linspace(-4, 4, nbins_a + 1)
+
+        print(data_a.dims)
+        reduce_dim, broadcast_dim = data_a.dims
+        h = histogram(data_a, bins=[bins_a], dim=reduce_dim).transpose()
+
+        assert h.shape == (nbins_a, data_a.sizes[broadcast_dim])
+
+        def _np_hist(*args, **kwargs):
+            h, _ = np.histogram(*args, **kwargs)
+            return h
+        hist = np.apply_along_axis(_np_hist, axis=0, arr=data_a.values,
+                                   bins=bins_a)
+
+        np.testing.assert_allclose(hist, h.values)
+
+    def test_2d_chunks_2d_hist(self, dataarray_factory, xchunksize, ychunksize):
+
+        data_a = dataarray_factory(shape=(10, 12)).chunk((xchunksize, ychunksize))
+        data_b = dataarray_factory(shape=(10, 12)).chunk((xchunksize, ychunksize))
+
+        nbins_a = 8
+        nbins_b = 9
+        bins_a = np.linspace(-4, 4, nbins_a + 1)
+        bins_b = np.linspace(-4, 4, nbins_b + 1)
+
+        h = histogram(data_a, data_b, bins=[bins_a, bins_b])
+
+        assert h.shape == (nbins_a, nbins_b)
+
+        hist, _, _ = np.histogram2d(
+            data_a.values.ravel(), data_b.values.ravel(),
+            bins=[bins_a, bins_b],
+        )
+
+        np.testing.assert_allclose(hist, h.values)
+
+
+pytest.importorskip("hypothesis")
+
+import hypothesis.strategies as st
+from hypothesis import given
+
+
+@st.composite
+def chunk_shapes(draw, ndim=3, max_arr_len=10):
+    """Generate different chunking patterns for an N-D array of data."""
+    chunks = []
+    for n in range(ndim):
+        shape = draw(st.integers(min_value=1, max_value=max_arr_len))
+        chunks.append(shape)
+    return tuple(chunks)
+
+
+# TODO group into class
+
+@given(chunk_shapes(ndim=1, max_arr_len=20))
+def test_all_chunking_patterns_1d(dataarray_factory, chunks):
+
+    data = dataarray_factory(shape=(20,)).chunk(chunks)
+
+    nbins_a = 8
+    bins = np.linspace(-4, 4, nbins_a + 1)
+
+    h = histogram(data, bins=[bins])
+
+    assert h.shape == (nbins_a,)
+
+    hist, _ = np.histogram(
+        data.values.ravel(),
+        bins=bins,
+    )
+
+    np.testing.assert_allclose(hist, h)
+
+
+# TODO mark as slow?
+@given(chunk_shapes(ndim=2, max_arr_len=8))
+def test_all_chunking_patterns_2d(dataarray_factory, chunks):
+
+    data_a = dataarray_factory(shape=(5,20)).chunk(chunks)
+    data_b = dataarray_factory(shape=(5,20)).chunk(chunks)
+
+    nbins_a = 8
+    nbins_b = 9
+    bins_a = np.linspace(-4, 4, nbins_a + 1)
+    bins_b = np.linspace(-4, 4, nbins_b + 1)
+
+    h = histogram(data_a, data_b, bins=[bins_a, bins_b])
+
+    assert h.shape == (nbins_a, nbins_b)
+
+    hist, _, _ = np.histogram2d(
+        data_a.values.ravel(), data_b.values.ravel(),
+        bins=[bins_a, bins_b],
+    )
+
+    np.testing.assert_allclose(hist, h.values)
+
+
+# TODO mark as slow?
+@pytest.mark.parametrize("n_vars", [1, 2, 3, 4])
+#@given(chunk_shapes(ndim=2, max_arr_len=7))
+def test_all_chunking_patterns_dd_hist(dataset_factory, n_vars, chunk_shapes=(1,1)):
+    ds = dataset_factory(ndim=2, n_vars=n_vars)
+    #print(ds.dims)
+    ds = ds.chunk({d: c for d, c in zip(ds.dims.keys(), chunk_shapes)})
+
+    #print(ds)
+    #print(ds[name] for name in ds.items())
+    n_bins = (7, 8, 9, 10)[:n_vars]
+    bins = [np.linspace(-4, 4, n + 1) for n in n_bins]
+
+    #print(*[da for name, da in ds.data_vars.items()])
+
+    print(bins)
+    h = histogram(*[da for name, da in ds.data_vars.items()], bins=bins)
+
+
+    #print(h)
+
+    assert h.shape == n_bins
+
+    input_data = np.stack([da.values.ravel() for name, da in ds.data_vars.items()],
+                          axis=-1)
+    print(input_data)
+    hist, _ = np.histogramdd(input_data, bins=bins)
+
+    np.testing.assert_allclose(hist, h.values)

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -11,7 +11,7 @@ from ..xarray import histogram
 def test_chunked_weights(chunksize, shape, weights):
 
     data_a = example_dataarray(shape).chunk((chunksize,))
-    
+
     if weights:
         weights = example_dataarray(shape).chunk((chunksize,))
         weights_arr = weights.values.ravel()
@@ -25,8 +25,7 @@ def test_chunked_weights(chunksize, shape, weights):
 
     assert h.shape == (nbins_a,)
 
-    hist, _ = np.histogram(data_a.values.ravel(), bins=bins_a,
-                           weights=weights_arr)
+    hist, _ = np.histogram(data_a.values.ravel(), bins=bins_a, weights=weights_arr)
 
     np.testing.assert_allclose(hist, h.values)
 

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -147,8 +147,8 @@ class TestChunkingHypotheses:
 
     # TODO mark as slow?
     @pytest.mark.parametrize("n_vars", [1, 2, 3, 4])
-    #@given(chunk_shapes(ndim=2, max_arr_len=7))
-    def test_all_chunking_patterns_dd_hist(self, dataset_factory, n_vars, chunk_shapes=(1,1)):
+    @given(chunk_shapes(ndim=2, max_arr_len=7))
+    def test_all_chunking_patterns_dd_hist(self, dataset_factory, n_vars, chunk_shapes):
         ds = dataset_factory(ndim=2, n_vars=n_vars)
         ds = ds.chunk({d: c for d, c in zip(ds.dims.keys(), chunk_shapes)})
 

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -54,7 +54,7 @@ class TestFixedSize2DChunks:
         bins_a = np.linspace(-4, 4, nbins_a + 1)
 
         reduce_dim, broadcast_dim = data_a.dims
-        h = histogram(data_a, bins=[bins_a], dim=reduce_dim).transpose()
+        h = histogram(data_a, bins=[bins_a], dim=(reduce_dim,)).transpose()
 
         assert h.shape == (nbins_a, data_a.sizes[broadcast_dim])
 

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -99,7 +99,6 @@ class TestFixedSize2DChunks:
 class TestUnalignedChunks:
     def test_unaligned_data_chunks(self, xchunksize, ychunksize):
         data_a = example_dataarray(shape=(10, 12)).chunk((xchunksize, ychunksize))
-        print(data_a.chunks)
         data_b = example_dataarray(shape=(10, 12)).chunk(
             (xchunksize + 1, ychunksize + 1)
         )

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -53,7 +53,6 @@ class TestFixedSize2DChunks:
         nbins_a = 8
         bins_a = np.linspace(-4, 4, nbins_a + 1)
 
-        print(data_a.dims)
         reduce_dim, broadcast_dim = data_a.dims
         h = histogram(data_a, bins=[bins_a], dim=reduce_dim).transpose()
 

--- a/xhistogram/test/test_chunking.py
+++ b/xhistogram/test/test_chunking.py
@@ -1,12 +1,13 @@
+# flake8: noqa
 import numpy as np
 import pytest
 
-from .fixtures import dataarray_factory, dataset_factory
+from .fixtures import dataarray_factory, dataset_factory  # noqa
 from ..xarray import histogram
 
 
 @pytest.mark.parametrize("chunksize", [1, 2, 3, 10])
-@pytest.mark.parametrize("shape", [(10,), (10,4)])
+@pytest.mark.parametrize("shape", [(10,), (10, 4)])
 def test_fixed_size_1d_chunks(dataarray_factory, chunksize, shape):
 
     data_a = dataarray_factory(shape).chunk((chunksize,))
@@ -41,7 +42,12 @@ class TestFixedSize2DChunks:
 
         np.testing.assert_allclose(hist, h.values)
 
-    def test_2d_chunks_broadcast_dim(self, dataarray_factory, xchunksize, ychunksize):
+    def test_2d_chunks_broadcast_dim(
+        self,
+        dataarray_factory,
+        xchunksize,
+        ychunksize,
+    ):
         data_a = dataarray_factory(shape=(10, 12)).chunk((xchunksize, ychunksize))
 
         nbins_a = 8
@@ -56,8 +62,8 @@ class TestFixedSize2DChunks:
         def _np_hist(*args, **kwargs):
             h, _ = np.histogram(*args, **kwargs)
             return h
-        hist = np.apply_along_axis(_np_hist, axis=0, arr=data_a.values,
-                                   bins=bins_a)
+
+        hist = np.apply_along_axis(_np_hist, axis=0, arr=data_a.values, bins=bins_a)
 
         np.testing.assert_allclose(hist, h.values)
 
@@ -76,89 +82,9 @@ class TestFixedSize2DChunks:
         assert h.shape == (nbins_a, nbins_b)
 
         hist, _, _ = np.histogram2d(
-            data_a.values.ravel(), data_b.values.ravel(),
+            data_a.values.ravel(),
+            data_b.values.ravel(),
             bins=[bins_a, bins_b],
         )
-
-        np.testing.assert_allclose(hist, h.values)
-
-
-# TODO should these live in a different file again?
-pytest.importorskip("hypothesis")
-
-import hypothesis.strategies as st
-from hypothesis import given
-
-
-@st.composite
-def chunk_shapes(draw, ndim=3, max_arr_len=10):
-    """Generate different chunking patterns for an N-D array of data."""
-    chunks = []
-    for n in range(ndim):
-        shape = draw(st.integers(min_value=1, max_value=max_arr_len))
-        chunks.append(shape)
-    return tuple(chunks)
-
-
-class TestChunkingHypotheses:
-    @given(chunk_shapes(ndim=1, max_arr_len=20))
-    def test_all_chunking_patterns_1d(self, dataarray_factory, chunks):
-
-        data = dataarray_factory(shape=(20,)).chunk(chunks)
-
-        nbins_a = 8
-        bins = np.linspace(-4, 4, nbins_a + 1)
-
-        h = histogram(data, bins=[bins])
-
-        assert h.shape == (nbins_a,)
-
-        hist, _ = np.histogram(
-            data.values.ravel(),
-            bins=bins,
-        )
-
-        np.testing.assert_allclose(hist, h)
-
-    # TODO mark as slow?
-    @given(chunk_shapes(ndim=2, max_arr_len=8))
-    def test_all_chunking_patterns_2d(self, dataarray_factory, chunks):
-
-        data_a = dataarray_factory(shape=(5,20)).chunk(chunks)
-        data_b = dataarray_factory(shape=(5,20)).chunk(chunks)
-
-        nbins_a = 8
-        nbins_b = 9
-        bins_a = np.linspace(-4, 4, nbins_a + 1)
-        bins_b = np.linspace(-4, 4, nbins_b + 1)
-
-        h = histogram(data_a, data_b, bins=[bins_a, bins_b])
-
-        assert h.shape == (nbins_a, nbins_b)
-
-        hist, _, _ = np.histogram2d(
-            data_a.values.ravel(), data_b.values.ravel(),
-            bins=[bins_a, bins_b],
-        )
-
-        np.testing.assert_allclose(hist, h.values)
-
-    # TODO mark as slow?
-    @pytest.mark.parametrize("n_vars", [1, 2, 3, 4])
-    @given(chunk_shapes(ndim=2, max_arr_len=7))
-    def test_all_chunking_patterns_dd_hist(self, dataset_factory, n_vars, chunk_shapes):
-        ds = dataset_factory(ndim=2, n_vars=n_vars)
-        ds = ds.chunk({d: c for d, c in zip(ds.dims.keys(), chunk_shapes)})
-
-        n_bins = (7, 8, 9, 10)[:n_vars]
-        bins = [np.linspace(-4, 4, n + 1) for n in n_bins]
-
-        h = histogram(*[da for name, da in ds.data_vars.items()], bins=bins)
-
-        assert h.shape == n_bins
-
-        input_data = np.stack([da.values.ravel() for name, da in ds.data_vars.items()],
-                              axis=-1)
-        hist, _ = np.histogramdd(input_data, bins=bins)
 
         np.testing.assert_allclose(hist, h.values)

--- a/xhistogram/test/test_chunking_hypotheses.py
+++ b/xhistogram/test/test_chunking_hypotheses.py
@@ -11,17 +11,17 @@ from hypothesis import given
 
 
 @st.composite
-def chunk_shapes(draw, ndim=3, max_arr_len=10):
+def chunk_shapes(draw, n_dim=3, max_arr_len=10):
     """Generate different chunking patterns for an N-D array of data."""
     chunks = []
-    for n in range(ndim):
+    for n in range(n_dim):
         shape = draw(st.integers(min_value=1, max_value=max_arr_len))
         chunks.append(shape)
     return tuple(chunks)
 
 
 class TestChunkingHypotheses:
-    @given(chunk_shapes(ndim=1, max_arr_len=20))
+    @given(chunk_shapes(n_dim=1, max_arr_len=20))
     def test_all_chunking_patterns_1d(self, dataarray_factory, chunks):
 
         data = dataarray_factory(shape=(20,)).chunk(chunks)
@@ -41,7 +41,7 @@ class TestChunkingHypotheses:
         np.testing.assert_allclose(hist, h)
 
     # TODO mark as slow?
-    @given(chunk_shapes(ndim=2, max_arr_len=8))
+    @given(chunk_shapes(n_dim=2, max_arr_len=8))
     def test_all_chunking_patterns_2d(self, dataarray_factory, chunks):
 
         data_a = dataarray_factory(shape=(5, 20)).chunk(chunks)
@@ -66,9 +66,9 @@ class TestChunkingHypotheses:
 
     # TODO mark as slow?
     @pytest.mark.parametrize("n_vars", [1, 2, 3, 4])
-    @given(chunk_shapes(ndim=2, max_arr_len=7))
+    @given(chunk_shapes(n_dim=2, max_arr_len=7))
     def test_all_chunking_patterns_dd_hist(self, dataset_factory, n_vars, chunk_shapes):
-        ds = dataset_factory(ndim=2, n_vars=n_vars)
+        ds = dataset_factory(n_dim=2, n_vars=n_vars)
         ds = ds.chunk({d: c for d, c in zip(ds.dims.keys(), chunk_shapes)})
 
         n_bins = (7, 8, 9, 10)[:n_vars]

--- a/xhistogram/test/test_chunking_hypotheses.py
+++ b/xhistogram/test/test_chunking_hypotheses.py
@@ -1,13 +1,13 @@
 import numpy as np
 import pytest
 
-from .fixtures import dataarray_factory, dataset_factory
+from .fixtures import example_dataarray, example_dataset
 from ..xarray import histogram
 
 pytest.importorskip("hypothesis")
 
-import hypothesis.strategies as st
-from hypothesis import given
+import hypothesis.strategies as st  # noqa
+from hypothesis import given  # noqa
 
 
 @st.composite
@@ -22,9 +22,9 @@ def chunk_shapes(draw, n_dim=3, max_arr_len=10):
 
 class TestChunkingHypotheses:
     @given(chunk_shapes(n_dim=1, max_arr_len=20))
-    def test_all_chunking_patterns_1d(self, dataarray_factory, chunks):
+    def test_all_chunking_patterns_1d(self, chunks):
 
-        data = dataarray_factory(shape=(20,)).chunk(chunks)
+        data = example_dataarray(shape=(20,)).chunk(chunks)
 
         nbins_a = 8
         bins = np.linspace(-4, 4, nbins_a + 1)
@@ -42,10 +42,10 @@ class TestChunkingHypotheses:
 
     # TODO mark as slow?
     @given(chunk_shapes(n_dim=2, max_arr_len=8))
-    def test_all_chunking_patterns_2d(self, dataarray_factory, chunks):
+    def test_all_chunking_patterns_2d(self, chunks):
 
-        data_a = dataarray_factory(shape=(5, 20)).chunk(chunks)
-        data_b = dataarray_factory(shape=(5, 20)).chunk(chunks)
+        data_a = example_dataarray(shape=(5, 20)).chunk(chunks)
+        data_b = example_dataarray(shape=(5, 20)).chunk(chunks)
 
         nbins_a = 8
         nbins_b = 9
@@ -67,8 +67,8 @@ class TestChunkingHypotheses:
     # TODO mark as slow?
     @pytest.mark.parametrize("n_vars", [1, 2, 3, 4])
     @given(chunk_shapes(n_dim=2, max_arr_len=7))
-    def test_all_chunking_patterns_dd_hist(self, dataset_factory, n_vars, chunk_shapes):
-        ds = dataset_factory(n_dim=2, n_vars=n_vars)
+    def test_all_chunking_patterns_dd_hist(self, n_vars, chunk_shapes):
+        ds = example_dataset(n_dim=2, n_vars=n_vars)
         ds = ds.chunk({d: c for d, c in zip(ds.dims.keys(), chunk_shapes)})
 
         n_bins = (7, 8, 9, 10)[:n_vars]

--- a/xhistogram/test/test_chunking_hypotheses.py
+++ b/xhistogram/test/test_chunking_hypotheses.py
@@ -1,0 +1,86 @@
+import numpy as np
+import pytest
+
+from .fixtures import dataarray_factory, dataset_factory
+from ..xarray import histogram
+
+pytest.importorskip("hypothesis")
+
+import hypothesis.strategies as st
+from hypothesis import given
+
+
+@st.composite
+def chunk_shapes(draw, ndim=3, max_arr_len=10):
+    """Generate different chunking patterns for an N-D array of data."""
+    chunks = []
+    for n in range(ndim):
+        shape = draw(st.integers(min_value=1, max_value=max_arr_len))
+        chunks.append(shape)
+    return tuple(chunks)
+
+
+class TestChunkingHypotheses:
+    @given(chunk_shapes(ndim=1, max_arr_len=20))
+    def test_all_chunking_patterns_1d(self, dataarray_factory, chunks):
+
+        data = dataarray_factory(shape=(20,)).chunk(chunks)
+
+        nbins_a = 8
+        bins = np.linspace(-4, 4, nbins_a + 1)
+
+        h = histogram(data, bins=[bins])
+
+        assert h.shape == (nbins_a,)
+
+        hist, _ = np.histogram(
+            data.values.ravel(),
+            bins=bins,
+        )
+
+        np.testing.assert_allclose(hist, h)
+
+    # TODO mark as slow?
+    @given(chunk_shapes(ndim=2, max_arr_len=8))
+    def test_all_chunking_patterns_2d(self, dataarray_factory, chunks):
+
+        data_a = dataarray_factory(shape=(5, 20)).chunk(chunks)
+        data_b = dataarray_factory(shape=(5, 20)).chunk(chunks)
+
+        nbins_a = 8
+        nbins_b = 9
+        bins_a = np.linspace(-4, 4, nbins_a + 1)
+        bins_b = np.linspace(-4, 4, nbins_b + 1)
+
+        h = histogram(data_a, data_b, bins=[bins_a, bins_b])
+
+        assert h.shape == (nbins_a, nbins_b)
+
+        hist, _, _ = np.histogram2d(
+            data_a.values.ravel(),
+            data_b.values.ravel(),
+            bins=[bins_a, bins_b],
+        )
+
+        np.testing.assert_allclose(hist, h.values)
+
+    # TODO mark as slow?
+    @pytest.mark.parametrize("n_vars", [1, 2, 3, 4])
+    @given(chunk_shapes(ndim=2, max_arr_len=7))
+    def test_all_chunking_patterns_dd_hist(self, dataset_factory, n_vars, chunk_shapes):
+        ds = dataset_factory(ndim=2, n_vars=n_vars)
+        ds = ds.chunk({d: c for d, c in zip(ds.dims.keys(), chunk_shapes)})
+
+        n_bins = (7, 8, 9, 10)[:n_vars]
+        bins = [np.linspace(-4, 4, n + 1) for n in n_bins]
+
+        h = histogram(*[da for name, da in ds.data_vars.items()], bins=bins)
+
+        assert h.shape == n_bins
+
+        input_data = np.stack(
+            [da.values.ravel() for name, da in ds.data_vars.items()], axis=-1
+        )
+        hist, _ = np.histogramdd(input_data, bins=bins)
+
+        np.testing.assert_allclose(hist, h.values)

--- a/xhistogram/test/test_chunking_hypotheses.py
+++ b/xhistogram/test/test_chunking_hypotheses.py
@@ -34,7 +34,7 @@ class TestChunkingHypotheses:
         assert h.shape == (nbins_a,)
 
         hist, _ = np.histogram(
-            data.values.ravel(),
+            data.values,
             bins=bins,
         )
 


### PR DESCRIPTION
This builds on #49 by adding a pretty comprehensive set of tests of different chunking arrangements. 

There are some normal tests, and some tests that use the [Hypothesis library](https://github.com/HypothesisWorks/hypothesis) to try out all sorts of different chunk shapes (inspired by @rabernat 's [similar test in the rechunker library](https://github.com/pangeo-data/rechunker/blob/40f2aa945cce73dea7e5239434016f7ed55218a6/tests/test_algorithm.py#L189-L207)).

There are some failures, but I *think* that they are because sometimes dask decides it knows better than me and changes the chunks:
```python
  /home/tegn500/Documents/Work/Code/xhistogram/xhistogram/core.py:334: 
  PerformanceWarning: Increasing number of chunks by factor of 100
    bin_counts = dsa.blockwise(
```
I'm not quite sure how that causes those tests to fail though - I'm not even sure that behaviour is deterministic.

How do I turn this feature off @jrbourbeau @gjoseph92 ? Or alternatively how do I debug what happened tp cause those tests to fail?