### PR TITLE
Pass weights to histogram_bin_edges

### DIFF
--- a/xhistogram/core.py
+++ b/xhistogram/core.py
@@ -379,7 +379,10 @@ def histogram(
             )
     else:
         bins = [
-            np.histogram_bin_edges(a, b, r) for a, b, r in zip(all_arrays, bins, range)
+            np.histogram_bin_edges(
+                a, bins=b, range=r, weights=all_arrays[-1] if has_weights else None
+            )
+            for a, b, r in zip(all_arrays, bins, range)
         ]
     bincount_kwargs = dict(
         weights=has_weights,


### PR DESCRIPTION
To simplify the implementation of #49 we stopped passing `weights` on to numpy's `histogram_bin_edges`. While it's true that `weights` is not used by this function at the moment, it may be used in the future. Following #61, it's now trivial to pass `weights` on. 

I'm not sure what a test for this would look like since `weights` doesn't actually do anything here.