### PR TITLE
make dask optional for xhistogram.core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,12 @@ CLASSIFIERS = [
     "Topic :: Scientific/Engineering",
 ]
 
-INSTALL_REQUIRES = ["xarray>=0.12.0", "dask[array]", "numpy>=1.17"]
+INSTALL_REQUIRES = ["numpy>=1.17"]
 PYTHON_REQUIRES = ">=3.7"
+EXTRAS_REQUIRE = {
+    "xarray": ["xarray>=0.12.0"],
+    "dask": ["dask[array]"]
+}
 
 DESCRIPTION = "Fast, flexible, label-aware histograms for numpy and xarray"
 
@@ -42,6 +46,7 @@ setup(
     description=DESCRIPTION,
     long_description=readme(),
     install_requires=INSTALL_REQUIRES,
+    extras_require=EXTRAS_REQUIRE,
     python_requires=PYTHON_REQUIRES,
     url=URL,
     packages=find_packages(),

--- a/xhistogram/core.py
+++ b/xhistogram/core.py
@@ -3,7 +3,6 @@ Numpy API for xhistogram.
 """
 
 
-import dask
 import numpy as np
 from functools import reduce
 from collections.abc import Iterable
@@ -336,7 +335,7 @@ def histogram(
     ndim = a0.ndim
     n_inputs = len(args)
 
-    is_dask_array = any([dask.is_dask_collection(a) for a in args])
+    is_dask_array = _any_dask_array(*args)
 
     if axis is not None:
         axis = np.atleast_1d(axis)


### PR DESCRIPTION
sometimes I'd need only numpy solution, just to be able to apply histogram along numpy axis. Would it possible to make dask / xarray dependencies optional?