### PR TITLE
Ensure args to xhistogram.xarray is a list

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -140,6 +140,21 @@ Preparing Pull Requests
 Release History
 ---------------
 
+v0.3.2 (not released)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Fix bug producing TypeError when weights is provided with
+  keep_coords=True :issue:`78`. By
+  `Dougie Squire <https://github.com/dougiesquire>`_.
+- Raise TypeError when weights is a dask array and bin edges are
+  not explicitly provided :issue:`12`. By
+  `Dougie Squire <https://github.com/dougiesquire>`_.
+
+v0.3.1
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Add DOI badge and CITATION.cff. By
+  `Julius Busecke <https://github.com/jbusecke>`_.
 
 v0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -144,7 +144,7 @@ v0.3.2 (not released)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Fix bug producing TypeError when weights is provided with
-  keep_coords=True :issue:`78`. By
+  `keep_coords=True` :issue:`78`. By
   `Dougie Squire <https://github.com/dougiesquire>`_.
 - Raise TypeError when weights is a dask array and bin edges are
   not explicitly provided :issue:`12`. By

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.9
   - xarray
   - netcdf4
-  - numpy>=1.16
+  - numpy>=1.16,!=1.20
   - pytest
   - numpydoc
   - sphinx

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.9
   - xarray
   - netcdf4
-  - numpy>=1.16,!=1.20
+  - numpy>=1.16
   - pytest
   - numpydoc
   - sphinx

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - python=3.9
   - xarray
   - netcdf4
-  - numpy>=1.16
+  - numpy>=1.16,!=1.20.0,!=1.20.1,!=1.20.2,!=1.20.3
   - pytest
   - numpydoc
   - sphinx

--- a/xhistogram/test/test_xarray.py
+++ b/xhistogram/test/test_xarray.py
@@ -175,24 +175,34 @@ def test_dims_and_coords():
 
 @pytest.mark.parametrize("number_of_inputs", [1, 2])
 @pytest.mark.parametrize("keep_coords", [True, False])
-def test_carry_coords(keep_coords, number_of_inputs):
+@pytest.mark.parametrize("include_weights", [True, False])
+def test_carry_coords(keep_coords, number_of_inputs, include_weights):
     time_axis = np.arange(40)
     X_axis = np.arange(10)
     Y_axis = np.arange(10)
+    weight_value = 0.5
+
     data = np.random.randint(
         low=0, high=100, size=(len(time_axis), len(X_axis), len(Y_axis))
     )
     da = xr.DataArray(
         data, coords=[time_axis, X_axis, Y_axis], dims=["time", "X", "Y"], name="one"
     )
+
+    if include_weights:
+        weights = xr.full_like(da, weight_value)
+    else:
+        weights = None
+
     # faking coordinates
-    da["lon"] = da.X ** 2 + da.Y ** 2
+    da["lon"] = da.X**2 + da.Y**2
     assert "lon" in da.coords
     bins = np.linspace(0, 100, 10)
     result = histogram(
         *[da] * number_of_inputs,
         bins=[bins] * number_of_inputs,
         dim=["time"],
+        weights=weights,
         keep_coords=keep_coords
     )
     if keep_coords:

--- a/xhistogram/xarray.py
+++ b/xhistogram/xarray.py
@@ -100,6 +100,7 @@ def histogram(
 
     """
 
+    args = list(args)
     N_args = len(args)
 
     # TODO: allow list of weights as well


### PR DESCRIPTION
Currently, providing `weights` with `keep_coords=True` produces a TypeError when `args` (a tuple) and `weights` (a list) are concatenated. This PR ensures that `args` is a list.

Closes #78 