### PR TITLE
Remove time deadline from slow Hypothesis tests

### DIFF
--- a/xhistogram/test/test_chunking_hypotheses.py
+++ b/xhistogram/test/test_chunking_hypotheses.py
@@ -41,6 +41,7 @@ class TestChunkingHypotheses:
         np.testing.assert_allclose(hist, h)
 
     # TODO mark as slow?
+    @settings(deadline=None)
     @given(chunk_shapes(n_dim=2, max_arr_len=8))
     def test_all_chunking_patterns_2d(self, chunks):
 


### PR DESCRIPTION
As described in https://github.com/xgcm/xhistogram/issues/74, some of the tests run with hypothesis fail intermittently. The error message suggests that this is due to the tests exceeding the default deadline in some hypothesis cases. In https://github.com/xgcm/xhistogram/pull/81, I removed the deadline for one of the slow tests in question and it seemed to help. But I missed another slow test. This PR removes the deadline for that test.